### PR TITLE
Use users access level for be group determination

### DIFF
--- a/Classes/ResourceServer/GitLab.php
+++ b/Classes/ResourceServer/GitLab.php
@@ -234,7 +234,7 @@ class GitLab extends AbstractResourceServer
                 'username' => $this->getUsernameFromUser($user),
                 'usergroup' => $this->getUserGroupsForUser(
                     $this->gitlabDefaultGroups,
-                    $this->adminUserLevel,
+                    $this->gitlabProjectPermissions['access_level'],
                     $authentificationInformation['db_groups']['table']
                 ),
                 'options' => $this->userOption


### PR DESCRIPTION
Use the users access level belonging to the project to determine which be user group should be assigned during login.

Fixes #2 