### PR TITLE
Mark conflict with league/oauth2-client 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
     "php-http/guzzle6-adapter": "^1.1",
     "typo3/cms-core": "^8.7||^9.4",
     "typo3/cms-beuser": "^8.7||^9.4"
+  },
+  "conflict": {
+    "league/oauth2-client": "^2.4"
   }
 }


### PR DESCRIPTION
There is currently an issue with current version of omines/oauth2-gitlab and the newly released version of league/oauth2-client 2.4.

Argument Type in *AbstractProvider::getResourceOwnerDetailsUrl* changed from `AccessToken` to `AccessTokenInterface` with breaks the inheritance currently.

This change can be reverted as soon as omines/oauth2-gitlab releases a new compatible version.