### PR TITLE
Limit session start

### DIFF
--- a/Classes/Services/OAuth2LoginService.php
+++ b/Classes/Services/OAuth2LoginService.php
@@ -68,7 +68,7 @@ class OAuth2LoginService extends AbstractService
         $this->authenticationInformation = $authenticationInformation;
         $this->parentObject = $parentObject;
 
-        if (!is_array($_SESSION)) {
+        if (!is_array($_SESSION) && $_GET['loginProvider'] === '1529672977') {
             @session_start();
         }
     }


### PR DESCRIPTION
Using session_start raises some problems in TYPO3 9.5.
By limiting it to login with defined loginProvider only the
possible side effects get circumvented.

Resolves #10 