### PR TITLE
[FIX] be_users column-name realName instead of realname

### DIFF
--- a/Classes/ResourceServer/GitLab.php
+++ b/Classes/ResourceServer/GitLab.php
@@ -241,7 +241,7 @@ class GitLab extends AbstractResourceServer
             $currentRecord,
             [
                 'email' => $userData['email'],
-                'realname' => $userData['name'],
+                'realName' => $userData['name'],
                 'username' => $this->getUsernameFromUser($user),
                 'usergroup' => $this->getUserGroupsForUser(
                     $this->gitlabDefaultGroups,


### PR DESCRIPTION
The columns definition is "realName". While this works with MySQL/MariaDB, this fails on e.g. PostgreSQL.