### PR TITLE
[FIX] use ext-key string instead of variable

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,7 +6,7 @@ use Mfc\OAuth2\Services\OAuth2LoginService;
 defined('TYPO3_MODE') || die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService(
-    $_EXTKEY,
+    'oauth2',
     'auth',
     OAuth2LoginService::class,
     [


### PR DESCRIPTION
You MUST use the extension name (e.g. "tt_address") instead of $_EXTKEY within the two configuration files as this variable is no longer loaded automatically.

see https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/BestPractises/ConfigurationFiles.html