### PR TITLE
[FIX] Use isset instead of is_array

### DIFF
--- a/Classes/Services/OAuth2LoginService.php
+++ b/Classes/Services/OAuth2LoginService.php
@@ -75,7 +75,7 @@ class OAuth2LoginService extends AbstractService implements SingletonInterface
         $this->authenticationInformation['db_groups']['table'] = (($subType = 'getUserBe') ? 'be_groups' : 'fe_groups');
         $this->dbUser = $this->authenticationInformation['db_user'];
 
-        if (!is_array($_SESSION) && $_GET['loginProvider'] === '1529672977') {
+        if (!isset($_SESSION) && $_GET['loginProvider'] === '1529672977') {
             @session_start();
         }
     }


### PR DESCRIPTION
This avoids PHP8 warning "PHP Warning: Undefined variable $_SESSION"