### PR TITLE
Add support for TYPO3 13.0

### DIFF
--- a/Classes/Services/OAuth2LoginService.php
+++ b/Classes/Services/OAuth2LoginService.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Database\Query\QueryHelper;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Security\RequestToken;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -72,8 +73,16 @@ class OAuth2LoginService extends AbstractAuthenticationService implements Logger
 
     public function getUser(): ?array
     {
-        if ($this->login['status'] !== LoginType::LOGIN) {
-            return null;
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 13) {
+            // TYPO3 >= 13
+            if (LoginType::tryFrom($this->login['status'] ?? '') !== LoginType::LOGIN) {
+                return null;
+            }
+        } else {
+            // TYPO3 < 13
+            if ($this->login['status'] !== LoginType::LOGIN) {
+                return null;
+            }
         }
 
         $request = $this->getRequest();

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,12 @@
   "require": {
     "php": "^7.4 || ^8.1",
     "league/oauth2-client": "^2.6",
-    "m4tthumphrey/php-gitlab-api": "^11.0",
+    "m4tthumphrey/php-gitlab-api": "^11.13.0",
     "omines/oauth2-gitlab": "^3.4",
     "php-http/guzzle7-adapter": "^1.0",
     "psr/http-factory": "^1.0",
-    "typo3/cms-core": "^12.2 || dev-main",
-    "typo3/cms-beuser": "^12.2 || dev-main"
+    "typo3/cms-core": "^12.2 || ^13.0 || dev-main",
+    "typo3/cms-beuser": "^12.2 || ^13.0 || dev-main"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
I've just added support for the freshly released TYPO3 version 13.0.
Note, that this support is still *experimental* and as the extension currently tries to be compatible with TYPO3 >= 11 it still uses classes that are deprecated in newer versions of TYPO3. Feel free to give it a try. :smiley: 