### PR TITLE
Implement TYPO3 14 compatibility

### DIFF
--- a/Classes/EventListener/BeforeRequestTokenProcessedListener.php
+++ b/Classes/EventListener/BeforeRequestTokenProcessedListener.php
@@ -22,10 +22,6 @@ final class BeforeRequestTokenProcessedListener
         }
 
         if (array_key_exists(RequestToken::PARAM_NAME, $request->getQueryParams())) {
-            if (!isset($_SESSION) && ($request->getQueryParams()['loginProvider'] ?? '') === '1529672977') {
-                @session_start();
-            }
-
             $jwt = $request->getQueryParams()[RequestToken::PARAM_NAME];
             $signingSecretResolver = $this->getSigningSecretResolver();
 

--- a/Classes/LoginProvider/OAuth2LoginProvider.php
+++ b/Classes/LoginProvider/OAuth2LoginProvider.php
@@ -7,10 +7,12 @@ namespace Mfc\OAuth2\LoginProvider;
 use Mfc\OAuth2\ResourceServer\Registry;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Backend\Controller\LoginController;
 use TYPO3\CMS\Backend\LoginProvider\LoginProviderInterface;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\View\ViewInterface;
 use TYPO3\CMS\Fluid\View\FluidViewAdapter;
+use TYPO3\CMS\Fluid\View\StandaloneView;
 
 #[Autoconfigure(public: true)]
 final readonly class OAuth2LoginProvider implements LoginProviderInterface
@@ -18,6 +20,14 @@ final readonly class OAuth2LoginProvider implements LoginProviderInterface
     public function __construct(
         private PageRenderer $pageRenderer,
     ) {}
+
+    /**
+     * @deprecated Satisfies the v13 LoginProviderInterface contract. TYPO3 v12+ prefers modifyView() and will not call this.
+     */
+    public function render(StandaloneView $view, PageRenderer $pageRenderer, LoginController $loginController): void
+    {
+        throw new \RuntimeException('Legacy interface implementation. Should not be called', 1724768908);
+    }
 
     public function modifyView(ServerRequestInterface $request, ViewInterface $view): string
     {

--- a/Classes/LoginProvider/OAuth2LoginProvider.php
+++ b/Classes/LoginProvider/OAuth2LoginProvider.php
@@ -7,12 +7,10 @@ namespace Mfc\OAuth2\LoginProvider;
 use Mfc\OAuth2\ResourceServer\Registry;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
-use TYPO3\CMS\Backend\Controller\LoginController;
 use TYPO3\CMS\Backend\LoginProvider\LoginProviderInterface;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\View\ViewInterface;
 use TYPO3\CMS\Fluid\View\FluidViewAdapter;
-use TYPO3\CMS\Fluid\View\StandaloneView;
 
 #[Autoconfigure(public: true)]
 final readonly class OAuth2LoginProvider implements LoginProviderInterface
@@ -20,14 +18,6 @@ final readonly class OAuth2LoginProvider implements LoginProviderInterface
     public function __construct(
         private PageRenderer $pageRenderer,
     ) {}
-
-    /**
-     * @deprecated Remove in v14 when method is removed from LoginProviderInterface
-     */
-    public function render(StandaloneView $view, PageRenderer $pageRenderer, LoginController $loginController): void
-    {
-        throw new \RuntimeException('Legacy interface implementation. Should not be called', 1724768908);
-    }
 
     public function modifyView(ServerRequestInterface $request, ViewInterface $view): string
     {

--- a/Classes/Services/OAuth2LoginService.php
+++ b/Classes/Services/OAuth2LoginService.php
@@ -22,9 +22,10 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use Symfony\Component\HttpFoundation\Cookie;
 use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Security\RequestToken;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -65,24 +66,12 @@ class OAuth2LoginService extends AbstractAuthenticationService implements Logger
         $this->authInfo['db_groups']['table'] = (($mode == 'getUserBE') ? 'be_groups' : 'fe_groups');
         $this->db_user = $this->authInfo['db_user'];
 
-        $request = $this->getRequest();
-        if (!isset($_SESSION) && ($request->getQueryParams()['loginProvider'] ?? '') === '1529672977') {
-            @session_start();
-        }
     }
 
     public function getUser(): ?array
     {
-        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 13) {
-            // TYPO3 >= 13
-            if (LoginType::tryFrom($this->login['status'] ?? '') !== LoginType::LOGIN) {
-                return null;
-            }
-        } else {
-            // TYPO3 < 13
-            if ($this->login['status'] !== LoginType::LOGIN) {
-                return null;
-            }
+        if (LoginType::tryFrom($this->login['status'] ?? '') !== LoginType::LOGIN) {
+            return null;
         }
 
         $request = $this->getRequest();
@@ -100,8 +89,6 @@ class OAuth2LoginService extends AbstractAuthenticationService implements Logger
                 return $this->findOrCreateUserByResourceOwner($resourceOwner);
             }
         }
-        unset($_SESSION['oauth2state']);
-
         return null;
     }
 
@@ -143,19 +130,26 @@ class OAuth2LoginService extends AbstractAuthenticationService implements Logger
     protected function sendOAuthRedirect(): void
     {
         [$authorizationUrl, $oauth2state, $nonceCookie] = $this->resourceServer->getAuthorizationUrl();
-        $_SESSION['oauth2state'] = $oauth2state;
+
+        $request = $this->getRequest();
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        $secure = $normalizedParams instanceof NormalizedParams && $normalizedParams->isHttps();
+        $path = $normalizedParams instanceof NormalizedParams ? $normalizedParams->getSitePath() : '/';
+        $stateCookie = new Cookie('typo3_oauth2_state', $oauth2state, 0, $path, null, $secure, true, false, Cookie::SAMESITE_LAX);
 
         $response = $this->responseFactory
             ->createResponse(303)
             ->withAddedHeader('location', $authorizationUrl)
-            ->withAddedHeader('Set-Cookie', (string)$nonceCookie);
+            ->withAddedHeader('Set-Cookie', (string)$nonceCookie)
+            ->withAddedHeader('Set-Cookie', (string)$stateCookie);
 
         throw new PropagateResponseException($response);
     }
 
     protected function isOAuthRedirectRequest(string $state): bool
     {
-        return $state === $_SESSION['oauth2state'];
+        $cookieState = $this->getRequest()->getCookieParams()['typo3_oauth2_state'] ?? null;
+        return $cookieState !== null && $state === $cookieState;
     }
 
     protected function getAccessToken(ServerRequestInterface $request): ?AccessToken

--- a/PR_65_DESCRIPTION
+++ b/PR_65_DESCRIPTION
@@ -1,0 +1,45 @@
+## Description
+
+This PR implements TYPO3 14 compatibility for the OAuth2 extension by addressing two critical issues:
+
+### 1. OAuth State Storage: Session → SameSite=Lax Cookie
+
+**Problem**: TYPO3 14's backend context enforces `SameSite=Strict` cookies, which are not sent by browsers on cross-site redirects (e.g., GitLab OAuth callbacks). This caused `$_SESSION['oauth2state']` to be undefined on the callback request, triggering TYPO3's error handler and resulting in fatal exceptions.
+
+**Solution**: Replace PHP session-based state storage with a `typo3_oauth2_state` cookie using `SameSite=Lax`, which correctly forwards on top-level cross-site navigations while maintaining security. The cookie includes:
+- Secure flag (when HTTPS)
+- HttpOnly flag
+- Site path from normalized params
+- Proper SameSite=Lax attribute
+
+**Changes**:
+- `OAuth2LoginService.php`: Replace session variable with cookie-based state storage in `sendOAuthRedirect()` and `isOAuthRedirectRequest()`
+- `BeforeRequestTokenProcessedListener.php`: Remove redundant `session_start()` calls
+- Remove deprecated session cleanup in `getUser()`
+
+### 2. Dead Code Removal & Compatibility Alignment
+
+**Problem**: 
+- Stale version checks for TYPO3 < 13 (now unsupported)
+- `render()` method references removed classes (`StandaloneView`) that were removed in TYPO3 14
+- Outdated `Typo3Version` utility usage
+
+**Solution**: Clean up dead code while maintaining v13 interface compatibility:
+- Remove TYPO3 < 13 version branching in `getUser()`
+- Restore `render()` stub in `OAuth2LoginProvider.php` to satisfy v13's `LoginProviderInterface` contract (method is never called since TYPO3 v12+ prefers `modifyView()`)
+- Type hints for `StandaloneView` and `LoginController` are safe because PHP resolves parameter types lazily
+- Remove unused `Typo3Version` import
+
+**Files Modified**: 3
+- `Classes/Services/OAuth2LoginService.php` (+14, -20)
+- `Classes/LoginProvider/OAuth2LoginProvider.php` (+1, -1)
+- `Classes/EventListener/BeforeRequestTokenProcessedListener.php` (-4)
+
+**Tested With**: TYPO3 13 & 14
+
+### Impact
+
+✅ Enables OAuth2 callbacks to work correctly in TYPO3 14
+✅ Maintains backward compatibility with TYPO3 13
+✅ Removes deprecated/dead code
+✅ Improves security with SameSite cookie flags


### PR DESCRIPTION
This PR adds TYPO3 14 support to the OAuth2 extension by addressing critical compatibility issues:

**Key Changes:**

1. OAuth State Storage Migration (Session → Cookie)

- TYPO3 14 enforces SameSite=Strict cookies, which block cross-site OAuth redirects
- Replaces session-based state tracking with a SameSite=Lax cookie (typo3_oauth2_state) that properly handles OAuth provider callbacks (GitLab, GitHub, etc.)
- Cookie includes security flags: Secure, HttpOnly, and appropriate SameSite handling

2. Dead Code Cleanup

- Removes version branching for TYPO3 < 13 (now unsupported)
- Removes redundant session_start() calls
- Maintains interface compatibility with TYPO3 v13 via stub methods
- Removes deprecated Typo3Version utility usage

**Impact:**

- ✅ Enables OAuth2 callbacks to work correctly in TYPO3 14
- ✅ Maintains backward compatibility with TYPO3 13
- ✅ Improves security posture with proper cookie configuration
